### PR TITLE
remove unused variable `drink`; added missing semicolons

### DIFF
--- a/09-challenge-1/spec/drinkSpec.js
+++ b/09-challenge-1/spec/drinkSpec.js
@@ -1,10 +1,9 @@
+// A test suite begins with a call to the global Jasmine function describe with two parameters: a string and a function.
 describe("My whatCanIDrink function", function() {
-    // A test suite begins with a call to the global Jasmine function describe with two parameters: a string and a function.
-    beforeEach(function() {
-        drink = new whatCanIDrink();
-    });
-    
+
+    // You can add "describe" functions one within the other to create a hierarchy of tests
     describe("Checks age", function() {
+
         // Specs are defined by calling the global Jasmine function it
         it("should exist", function() {
             // Expectations are built with the function expect which takes a value, called the actual.
@@ -14,33 +13,33 @@ describe("My whatCanIDrink function", function() {
         });
         
         it("should return drink toddy when called as whatCanIDrink(13)", function() {
-            var result = whatCanIDrink(13)
+            var result = whatCanIDrink(13);
             expect(result).toBe("Drink Toddy");
         });
         
         
         it("should return drink coke when called as whatCanIDrink(17)", function() {
-            var result = whatCanIDrink(17)
+            var result = whatCanIDrink(17);
             expect(result).toBe("Drink Coke");
         });
         
         it("should return drink beer when called as whatCanIDrink(18)", function() {
-            var result = whatCanIDrink(18)
+            var result = whatCanIDrink(18);
             expect(result).toBe("Drink Beer");
         });
         
         it("should return drink beer when called as whatCanIDrink(20)", function() {
-            var result = whatCanIDrink(20)
+            var result = whatCanIDrink(20);
             expect(result).toBe("Drink Beer");
         }); 
         
         it("should return drink whisky when called as whatCanIDrink(30)", function() {
-            var result = whatCanIDrink(30)
+            var result = whatCanIDrink(30);
             expect(result).toBe("Drink Whisky");
         });
         
         it("should be unable to return a drink when called as whatCanIDrink(140)", function() {
-            var result = whatCanIDrink(140)
+            var result = whatCanIDrink(140);
             expect(result).toBe("Sorry. I can’t tell what drink because that age is incorrect!");
         });
         


### PR DESCRIPTION
The unused variable was noticed by Sonya Cooley who reported this on Slack